### PR TITLE
option for not saving checkbox state regardless of globally save state setting of datatable.

### DIFF
--- a/js/dataTables.checkboxes.js
+++ b/js/dataTables.checkboxes.js
@@ -438,8 +438,12 @@ Checkboxes.prototype = {
             }
          });
 
+         var colSaveState = ctx.oFeatures.bStateSave;
+         if (typeof ctx.aoColumns[colIdx].checkboxes.saveState !== 'undefined'){
+            colSaveState = ctx.aoColumns[colIdx].checkboxes.saveState;
+         }
          // If state saving is enabled
-         if(ctx.oFeatures.bStateSave){
+         if(colSaveState){
             // Save state
             dt.state.save();
          }


### PR DESCRIPTION
comments #57 

Probable not ready.

````
var table = $('#example').DataTable({
    'ajax': 'http://api.myjson.com/bins/sh72r',
    'columns': [
      {
        'className':      'details-control',
        'orderable':      false,
        'data':           null,
        'defaultContent': ''
      },
      {
        'data': 'DT_RowId',
        'checkboxes': {
          'selectRow': true,
          'stateSave': false
        }
      },
      { 'data': 'first_name' },
      { 'data': 'last_name' },
      { 'data': 'position' },
      { 'data': 'office' },
      { 'data': 'salary' }
    ],
    'ignoreSelect': true,
    'select': {
      'style': 'multi',
      'selector': 'td:not(:first-child)'
    },
    'stateSave': true,
    'order': [[3, 'asc']]
  } );
````